### PR TITLE
fix broken looping logic when end trim handle is at the end

### DIFF
--- a/video_trimmer_library/src/main/java/com/lb/video_trimmer_library/BaseVideoTrimmerView.kt
+++ b/video_trimmer_library/src/main/java/com/lb/video_trimmer_library/BaseVideoTrimmerView.kt
@@ -237,7 +237,6 @@ abstract class BaseVideoTrimmerView @JvmOverloads constructor(
         }
         videoView.layoutParams = lp
         playView.visibility = View.VISIBLE
-        mp.isLooping = true
         duration = videoView.duration
         endPosition = getInitialEndPosition()
         setSeekBarPosition()
@@ -328,6 +327,14 @@ abstract class BaseVideoTrimmerView @JvmOverloads constructor(
 
     private fun onVideoCompleted() {
         videoView.seekTo(startPosition)
+        if( wasPlaying )
+        {
+            playVideo()
+        }
+        else
+        {
+            pauseVideo()
+        }
     }
 
     private fun notifyProgressUpdate(all: Boolean) {


### PR DESCRIPTION
fix looping bug (video completes and then starts from the beginning rather than going from the start trim handle position)